### PR TITLE
WIP: Add linkstate-edge processor

### DIFF
--- a/jalapeno-helm/templates/processors/linkstate-edge/processors-linkstate-edge-deploy.yaml
+++ b/jalapeno-helm/templates/processors/linkstate-edge/processors-linkstate-edge-deploy.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ .Values.processors.linkstateEdge.name }}"
+spec:
+  replicas: {{ .Values.processors.linkstateEdge.replicas }}
+  selector:
+    matchLabels:
+      app: "{{ .Values.processors.linkstateEdge.name }}"
+  template:
+    metadata:
+      labels:
+        app: "{{ .Values.processors.linkstateEdge.name }}"
+    spec:
+      volumes:
+        - name: credentials
+          secret:
+            secretName: {{ .Values.processors.linkstateEdge.name }}-secret
+      containers:
+        - image: "{{ .Values.processors.linkstateEdge.image }}"
+          imagePullPolicy: Always
+          name: linkstate-edge
+          volumeMounts:
+            - name: credentials
+              mountPath: /credentials
+          # TODO: arangodb name 
+          args:
+            - --v
+            - "5"
+            - --message-server
+            - "{{ .Values.kafka.fullnameOverride }}.{{ .Release.Namespace }}:9092"
+            - --database-server
+            #- "http://arangodb.{{ .Release.Namespace }}:8529"
+            - "http://jalapeno-arangodb:8086" # TODO Fix hardcoded value
+            - --database-name
+            - "{{ .Values.arangodb.databaseName }}"
+          {{- if .Values.collectors.gobmp.resources }}
+          resources:
+            {{- if .Values.collectors.gobmp.resources.requests }}
+            requests:
+              memory: {{ .Values.collectors.gobmp.resources.requests.memory | default "50Mi" | quote }}
+              cpu: {{ .Values.collectors.gobmp.resources.requests.cpu | default "10m" | quote }}
+            {{- else}}
+            requests:
+              memory: "50Mi"
+              cpu: "10m"
+            {{- end}}
+            {{- if .Values.collectors.gobmp.resources.limits }}
+            limits:
+              memory: {{ .Values.collectors.gobmp.resources.limits.memory | default "1024Mi" | quote }}
+              cpu: {{ .Values.collectors.gobmp.resources.limits.cpu | default "1" | quote }}
+            {{- else}}
+            limits:
+              memory: "1024Mi"
+              cpu: "1"
+            {{- end }}
+          {{- else }}
+          resources:
+            requests:
+              memory: "50Mi"
+              cpu: "10m"
+            limits:
+              memory: "1024Mi"
+              cpu: "1"
+          {{- end }}
+
+

--- a/jalapeno-helm/templates/processors/linkstate-edge/processors-lslinkstate-edge-secret.yaml
+++ b/jalapeno-helm/templates/processors/linkstate-edge/processors-lslinkstate-edge-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: "{{ .Values.processors.linkstateEdge.name }}-secret"
+type: Opaque
+data:
+    .username: {{ .Values.arangodb.databaseUser | b64enc }}
+    .password: {{ .Values.arangodb.databasePassword | b64enc }}

--- a/jalapeno-helm/values.yaml
+++ b/jalapeno-helm/values.yaml
@@ -51,6 +51,17 @@ processors:
     #   limits:
     #     memory:
     #     cpu:
+  linkstateEdge:
+    name: linkstate-edge
+    replicas: 1
+    image: docker.io/iejalapeno/linkstate-edge:latest
+    # resources:
+    #   requests:
+    #     memory:
+    #     cpu:
+    #   limits:
+    #     memory:
+    #     cpu:
   telegrafEgress:
     name: telegraf-egress
     replicas: 1


### PR DESCRIPTION
This PR includes the code to deploy the new link-state-edge processor. It should not be merged before the API gateway doesn't support the newly introduced edge fields. 