### PR TITLE
Update GoBMP and Telegraf Ingress to support different service types

### DIFF
--- a/jalapeno-helm/templates/collectors/gobmp/collector-gobmp-svc.yaml
+++ b/jalapeno-helm/templates/collectors/gobmp/collector-gobmp-svc.yaml
@@ -1,24 +1,39 @@
 apiVersion: v1
 kind: Service
+metadata:
+  name: {{ .Values.collectors.gobmp.name }}
+  {{- if .Values.collectors.gobmp.service.annotations }}
+  annotations:
+  {{- toYaml .Values.collectors.gobmp.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
+  {{- if (or (eq .Values.collectors.gobmp.service.type "ClusterIP") (empty .Values.collectors.gobmp.service.type)) }}
+  type: ClusterIP
+  {{- with .Values.collectors.gobmp.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- else if eq .Values.collectors.gobmp.service.type "LoadBalancer" }}
+  type: LoadBalancer
+  {{- with .Values.collectors.gobmp.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- else }}
+  type: {{ .Values.collectors.gobmp.service.type }}
+  {{- end }}
   ports:
   - name: incbmpsess
-    #nodePort: {{ .Values.collectors.gobmp.ports.incomingBMPSessions }}
+    protocol: TCP
     port: {{ .Values.collectors.gobmp.ports.incomingBMPSessions }}
-    protocol: TCP
     targetPort: 5000
-  - name: perfmon
-    #nodePort: {{ .Values.collectors.gobmp.ports.performanceMonitoring }}
-    port: {{ .Values.collectors.gobmp.ports.performanceMonitoring }}
-    protocol: TCP
-    targetPort: 56767
-  selector:
-    app: "{{ .Values.collectors.gobmp.name }}"
-  type: LoadBalancer
-  loadBalancerIP: {{ .Values.collectors.gobmp.service.loadBalancerIP }}
-metadata:
-  name: "{{ .Values.collectors.gobmp.name }}"
-  annotations:
-    {{- if .Values.collectors.gobmp.service.annotations }}
-    {{- toYaml .Values.collectors.gobmp.service.annotations | nindent 4 }}
+    {{- if (and (eq .Values.collectors.gobmp.service.type "NodePort") (not (empty .Values.collectors.gobmp.ports.incomingBMPSessions ))) }}
+    nodePort: {{ .Values.collectors.gobmp.ports.incomingBMPSessions }}
     {{- end }}
+  - name: perfmon
+    protocol: TCP
+    port: {{ .Values.collectors.gobmp.ports.performanceMonitoring }}
+    targetPort: 56767
+    {{- if (and (eq .Values.collectors.gobmp.service.type "NodePort") (not (empty .Values.collectors.gobmp.ports.performanceMonitoring ))) }}
+    nodePort: {{ .Values.collectors.gobmp.ports.performanceMonitoring }}
+    {{- end }}
+  selector:
+    app: {{ .Values.collectors.gobmp.name }}

--- a/jalapeno-helm/templates/collectors/gobmp/collector-gobmp-svc.yaml
+++ b/jalapeno-helm/templates/collectors/gobmp/collector-gobmp-svc.yaml
@@ -21,14 +21,14 @@ spec:
   type: {{ .Values.collectors.gobmp.service.type }}
   {{- end }}
   ports:
-  - name: incbmpsess
+  - name: incomingBMPSessions
     protocol: TCP
     port: {{ .Values.collectors.gobmp.ports.incomingBMPSessions }}
     targetPort: 5000
     {{- if (and (eq .Values.collectors.gobmp.service.type "NodePort") (not (empty .Values.collectors.gobmp.ports.incomingBMPSessions ))) }}
     nodePort: {{ .Values.collectors.gobmp.ports.incomingBMPSessions }}
     {{- end }}
-  - name: perfmon
+  - name: performanceMonitoring
     protocol: TCP
     port: {{ .Values.collectors.gobmp.ports.performanceMonitoring }}
     targetPort: 56767

--- a/jalapeno-helm/templates/collectors/telegraf-ingress/collector-telegraf-ingress-svc.yaml
+++ b/jalapeno-helm/templates/collectors/telegraf-ingress/collector-telegraf-ingress-svc.yaml
@@ -1,19 +1,32 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ .Values.collectors.telegrafIngress.name }}"
-  annotations:
+  name: {{ .Values.collectors.telegrafIngress.name }}
   {{- if .Values.collectors.telegrafIngress.service.annotations }}
+  annotations:
   {{- toYaml .Values.collectors.telegrafIngress.service.annotations | nindent 4 }}
   {{- end }}
 spec:
+  {{- if (or (eq .Values.collectors.telegrafIngress.service.type "ClusterIP") (empty .Values.collectors.telegrafIngress.service.type)) }}
+  type: ClusterIP
+  {{- with .Values.collectors.telegrafIngress.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- else if eq .Values.collectors.telegrafIngress.service.type "LoadBalancer" }}
   type: LoadBalancer
-  loadBalancerIP: {{ .Values.collectors.telegrafIngress.service.loadBalancerIP }}
+  {{- with .Values.collectors.telegrafIngress.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- else }}
+  type: {{ .Values.collectors.telegrafIngress.service.type }}
+  {{- end }}
   ports:
   - name: 57400-tcp
     protocol: TCP
     port: {{ .Values.collectors.telegrafIngress.port }}
-    # nodePort: {{ .Values.collectors.telegrafIngress.nodePort }}
     targetPort: 57400
+    {{- if (and (eq .Values.collectors.telegrafIngress.service.type "NodePort") (not (empty .Values.collectors.telegrafIngress.port))) }}
+    nodePort: {{ .Values.collectors.telegrafIngress.port }}
+    {{- end }}
   selector:
-    app: "{{ .Values.collectors.telegrafIngress.name }}"
+    app: {{ .Values.collectors.telegrafIngress.name }}

--- a/jalapeno-helm/values.yaml
+++ b/jalapeno-helm/values.yaml
@@ -6,6 +6,7 @@ collectors:
     name: gobmp
     replicas: 1
     image: docker.io/sbezverk/gobmp:latest
+    ## 'port' (and optionally 'nodePort') of service
     ports:
       incomingBMPSessions: 30511
       performanceMonitoring: 30767
@@ -17,15 +18,22 @@ collectors:
         memory: 1024Mi
         cpu: 1
     service:
+      ## Service type can be one of { ClusterIP, LoadBalancer, NodePort }
+      type: LoadBalancer
+      ## Configuration for service type 'LoadBalancer'
       loadBalancerIP: 172.16.19.64
+      ## Configuration for service type 'ClusterIP'
+      # clusterIP: 10.152.183.244
+      ## Optional annotations
       annotations:
         metallb.universe.tf/address-pool: load-balanced
 
   telegrafIngress:
     name: telegraf-ingress
     replicas: 1
-    image: telegraf:1.29-alpine
+    image: docker.io/telegraf:1.29-alpine
     imagePullSecret: regcred
+    ## 'port' (and optionally 'nodePort') of service
     port: 32400
     # resources:
     #   requests:
@@ -35,7 +43,13 @@ collectors:
     #     memory:
     #     cpu:
     service:
+      ## Service type can be one of { ClusterIP, LoadBalancer, NodePort }
+      type: LoadBalancer
+      ## Configuration for service type 'LoadBalancer'
       loadBalancerIP: 172.16.19.65
+      ## Configuration for service type 'ClusterIP'
+      # clusterIP: 10.152.183.1
+      ## Optional annotations
       annotations:
         metallb.universe.tf/address-pool: load-balanced
 
@@ -54,7 +68,7 @@ processors:
   telegrafEgress:
     name: telegraf-egress
     replicas: 1
-    image: telegraf:1.29-alpine
+    image: docker.io/telegraf:1.29-alpine
     imagePullSecret: regcred
     # resources:
     #   requests:


### PR DESCRIPTION
This change makes the type of the `gobmp` and `telegraf-ingress` services configurable (I needed to use NodePort instead of LoadBalancer to fit my use case).

This may break existing deployments due to new `.service.type` field, although I tried to keep the defaults intact as they were.