### PR TITLE
Update Telegraf Egress file output

### DIFF
--- a/jalapeno-helm/templates/processors/telegraf-egress/processors-telegraf-egress-cm.yaml
+++ b/jalapeno-helm/templates/processors/telegraf-egress/processors-telegraf-egress-cm.yaml
@@ -30,8 +30,6 @@ data:
       timeout = "5s"
 
     [[outputs.file]]
-      # Telegraf 1.29 crashes as it can not write to "metrics.out". Following default outputs.file configuration:
-      # https://github.com/influxdata/telegraf/blob/ee18866f3552bbc1debf25ce4e814efbb607d957/plugins/outputs/file/README.md
       files = ["stdout", "/tmp/metrics.out"]
       rotation_interval = "1h"
       rotation_max_size = "20MB"

--- a/jalapeno-helm/templates/processors/telegraf-egress/processors-telegraf-egress-cm.yaml
+++ b/jalapeno-helm/templates/processors/telegraf-egress/processors-telegraf-egress-cm.yaml
@@ -27,11 +27,12 @@ data:
       database = "{{ (index .Values.influxdb.influxdb.extraEnvVars 0).value }}"
       username = "{{ (index .Values.influxdb.influxdb.extraEnvVars 1).value }}"
       password = "{{ (index .Values.influxdb.influxdb.extraEnvVars 2).value }}"
-      precision = "s"
       timeout = "5s"
 
     [[outputs.file]]
-      files = ["metrics.out"]
+      # Telegraf 1.29 crashes as it can not write to "metrics.out". Following default outputs.file configuration:
+      # https://github.com/influxdata/telegraf/blob/ee18866f3552bbc1debf25ce4e814efbb607d957/plugins/outputs/file/README.md
+      files = ["stdout", "/tmp/metrics.out"]
       rotation_interval = "1h"
       rotation_max_size = "20MB"
       rotation_max_archives = 3


### PR DESCRIPTION
- Remove [deprecated](https://github.com/influxdata/telegraf/blob/138d0d54add1e3dcd70592d069bed4218bae2bd2/plugins/outputs/influxdb/influxdb.go#L60) `precision`
- Update targets of `outputs.file`: Telegraf 1.29 does not support writing in the current directory ("./metrics.out"), so it should write to `/tmp/metrics.out` instead (see [Telegraf file output docs](https://github.com/influxdata/telegraf/blob/ee18866f3552bbc1debf25ce4e814efbb607d957/plugins/outputs/file/README.md)). @severindellsperger also recommended writing to `stdout` as a best practice.

## Notes

Telegraf 1.29 crashes as it can not write to "metrics.out", so I recommend following the default outputs.file configuration: https://github.com/influxdata/telegraf/blob/ee18866f3552bbc1debf25ce4e814efbb607d957/plugins/outputs/file/README.md
