### PR TITLE
Hotfix invalid service port names for gobmp

### DIFF
--- a/jalapeno-helm/templates/collectors/gobmp/collector-gobmp-svc.yaml
+++ b/jalapeno-helm/templates/collectors/gobmp/collector-gobmp-svc.yaml
@@ -21,14 +21,14 @@ spec:
   type: {{ .Values.collectors.gobmp.service.type }}
   {{- end }}
   ports:
-  - name: incomingBMPSessions
+  - name: incbmpsess
     protocol: TCP
     port: {{ .Values.collectors.gobmp.ports.incomingBMPSessions }}
     targetPort: 5000
     {{- if (and (eq .Values.collectors.gobmp.service.type "NodePort") (not (empty .Values.collectors.gobmp.ports.incomingBMPSessions ))) }}
     nodePort: {{ .Values.collectors.gobmp.ports.incomingBMPSessions }}
     {{- end }}
-  - name: performanceMonitoring
+  - name: perfmon
     protocol: TCP
     port: {{ .Values.collectors.gobmp.ports.performanceMonitoring }}
     targetPort: 56767


### PR DESCRIPTION
A service port name needs to be RFC 1123 lowercase:

```
The Service "gobmp" is invalid:
* spec.ports[0].name: Invalid value: "incomingBMPSessions": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
* spec.ports[1].name: Invalid value: "performanceMonitoring": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```